### PR TITLE
feat: add 60dB AI provider integration for STT, TTS, and LLM services

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Follow the [installation guide](https://docs.n8n.io/integrations/community-nodes
 ## Operations
 
 ### Speech
-- Text to Speech
+- Text to Speech (provider: **ElevenLabs** or **60db**)
 - Speech to Text
 - Speech to Speech
 
@@ -28,9 +28,20 @@ Follow the [installation guide](https://docs.n8n.io/integrations/community-nodes
 - Create Clone
 - Delete
 
+## Text to Speech providers
+
+Text to Speech can run against two interchangeable providers, selected with the **Provider** dropdown. The rest of the workflow is unchanged — both return a single audio binary on the `data` property.
+
+- **ElevenLabs** — uses the ElevenLabs `text-to-speech` endpoint (voice list, models, output formats, voice settings).
+- **60db** — uses the [60db](https://docs.60db.ai) API with a selectable **Transport**:
+  - **HTTP** — `POST /tts-synthesize` (base64 JSON, decoded to binary)
+  - **Streaming** — `POST /tts-stream` (NDJSON chunks, concatenated)
+  - **WebSocket** — `wss://api.60db.ai/ws/tts` (LINEAR16/MULAW frames are wrapped in a WAV container)
+
 ## Credentials
 
-This node requires an API Key from ElevenLabs, You can generate one by going to your [Dashboard](https://elevenlabs.io/app/settings/api-keys).
+- **ElevenLabs API** — required for Voice operations, Speech to Text, Speech to Speech, and ElevenLabs Text to Speech. Generate a key from your [ElevenLabs Dashboard](https://elevenlabs.io/app/settings/api-keys).
+- **60db API** — required only when Text to Speech uses the 60db provider. The key is sent as a Bearer token (HTTP/streaming) and as the `apiKey` query parameter (WebSocket).
 
 ## Compatibility
 

--- a/credentials/SixtyDbApi.credentials.ts
+++ b/credentials/SixtyDbApi.credentials.ts
@@ -1,0 +1,34 @@
+import {
+	IAuthenticateGeneric,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
+
+export class SixtyDbApi implements ICredentialType {
+	name = 'sixtyDbApi';
+	displayName = '60db API';
+	documentationUrl = 'https://docs.60db.ai/api-reference';
+	properties: INodeProperties[] = [
+		{
+			displayName: '60db API Key',
+			name: 'apiKey',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+			placeholder: 'sk_live_...',
+			description: 'Your 60db API key. Sent as a Bearer token for HTTP/streaming and as the apiKey query parameter for the WebSocket transport.',
+		},
+	];
+
+	// HTTP and streaming transports authenticate with a Bearer token.
+	// The WebSocket transport reads `apiKey` directly (passed as a query param) since
+	// n8n's generic authenticator only injects HTTP headers.
+	authenticate: IAuthenticateGeneric = {
+		type: 'generic',
+		properties: {
+			headers: {
+				Authorization: '={{ "Bearer " + $credentials.apiKey }}',
+			},
+		},
+	};
+}

--- a/nodes/elevenlabs/Descriptions/speech.ts
+++ b/nodes/elevenlabs/Descriptions/speech.ts
@@ -76,6 +76,79 @@ export const SpeechOperations: INodeProperties[] = [
 export const SpeechFields: INodeProperties[] = [
 	// Text to Speech
 	{
+		displayName: 'Provider',
+		name: 'provider',
+		type: 'options',
+		noDataExpression: true,
+		description: 'Which text-to-speech provider to use. Both providers are interchangeable; the rest of the workflow does not change.',
+		options: [
+			{
+				name: 'ElevenLabs',
+				value: 'elevenLabs',
+				description: 'Use the ElevenLabs API (requires ElevenLabs API credentials)',
+			},
+			{
+				name: '60db',
+				value: '60db',
+				description: 'Use the 60db API (requires 60db API credentials)',
+			},
+		],
+		default: 'elevenLabs',
+		displayOptions: {
+			show: {
+				resource: ['speech'],
+				operation: ['textToSpeech'],
+			},
+		},
+	},
+	{
+		displayName: 'Transport',
+		name: 'transport',
+		type: 'options',
+		noDataExpression: true,
+		description: 'How to call the 60db API. All transports return a single audio binary; streaming and WebSocket assemble chunks before returning.',
+		options: [
+			{
+				name: 'HTTP',
+				value: 'http',
+				description: 'Simple request/response — POST /tts-synthesize',
+			},
+			{
+				name: 'Streaming (NDJSON)',
+				value: 'stream',
+				description: 'Chunked NDJSON audio — POST /tts-stream',
+			},
+			{
+				name: 'WebSocket',
+				value: 'websocket',
+				description: 'Real-time WebSocket synthesis — wss://api.60db.ai/ws/tts',
+			},
+		],
+		default: 'http',
+		displayOptions: {
+			show: {
+				resource: ['speech'],
+				operation: ['textToSpeech'],
+				provider: ['60db'],
+			},
+		},
+	},
+	{
+		displayName: 'Voice ID',
+		name: 'sixtyDbVoiceId',
+		type: 'string',
+		default: '',
+		placeholder: 'fbb75ed2-975a-40c7-9e06-38e30524a9a1',
+		description: 'The 60db voice ID to use for the conversion',
+		displayOptions: {
+			show: {
+				resource: ['speech'],
+				operation: ['textToSpeech'],
+				provider: ['60db'],
+			},
+		},
+	},
+	{
 		displayName: 'Voice',
 		description: 'Select the voice to use for the conversion',
 		name: 'voice',
@@ -85,6 +158,7 @@ export const SpeechFields: INodeProperties[] = [
 			show: {
 				resource: ['speech'],
 				operation: ['textToSpeech'],
+				provider: ['elevenLabs'],
 			},
 		},
 		modes: [
@@ -127,6 +201,110 @@ export const SpeechFields: INodeProperties[] = [
 			},
 		},
 	},
+	// 60db Additional Options
+	{
+		displayName: 'Additional Options',
+		name: 'sixtyDbOptions',
+		type: 'collection',
+		placeholder: 'Add Option',
+		default: {},
+		displayOptions: {
+			show: {
+				resource: ['speech'],
+				operation: ['textToSpeech'],
+				provider: ['60db'],
+			},
+		},
+		options: [
+			{
+				displayName: 'Audio Encoding',
+				name: 'audioEncoding',
+				type: 'options',
+				default: 'LINEAR16',
+				description: 'WebSocket audio encoding. LINEAR16 and MULAW are wrapped in a WAV container.',
+				// eslint-disable-next-line n8n-nodes-base/node-param-options-type-unsorted-items
+				options: [
+					{ name: 'LINEAR16 (PCM)', value: 'LINEAR16' },
+					{ name: 'MULAW', value: 'MULAW' },
+					{ name: 'OGG_OPUS', value: 'OGG_OPUS' },
+				],
+				displayOptions: {
+					show: {
+						'/transport': ['websocket'],
+					},
+				},
+			},
+			{
+				displayName: 'Enhance',
+				name: 'enhance',
+				type: 'boolean',
+				default: true,
+				description: 'Whether to apply audio quality enhancement',
+			},
+			{
+				displayName: 'Output Format',
+				name: 'outputFormat',
+				type: 'options',
+				default: 'mp3',
+				description: 'Audio container for the HTTP and streaming transports',
+				// eslint-disable-next-line n8n-nodes-base/node-param-options-type-unsorted-items
+				options: [
+					{ name: 'MP3', value: 'mp3' },
+					{ name: 'WAV', value: 'wav' },
+					{ name: 'OGG', value: 'ogg' },
+					{ name: 'FLAC', value: 'flac' },
+				],
+				displayOptions: {
+					show: {
+						'/transport': ['http', 'stream'],
+					},
+				},
+			},
+			{
+				displayName: 'Sample Rate',
+				name: 'sampleRate',
+				type: 'options',
+				default: 16000,
+				description: 'WebSocket output sample rate in Hz',
+				options: [
+					{ name: '8000 Hz', value: 8000 },
+					{ name: '16000 Hz', value: 16000 },
+					{ name: '24000 Hz', value: 24000 },
+					{ name: '48000 Hz', value: 48000 },
+				],
+				displayOptions: {
+					show: {
+						'/transport': ['websocket'],
+					},
+				},
+			},
+			{
+				displayName: 'Similarity',
+				name: 'similarity',
+				type: 'number',
+				default: 75,
+				typeOptions: { minValue: 0, maxValue: 100 },
+				description: 'How closely to match the source voice (0–100)',
+			},
+			{
+				displayName: 'Speed',
+				name: 'speed',
+				type: 'number',
+				default: 1,
+				typeOptions: { minValue: 0.5, maxValue: 2, numberPrecision: 2 },
+				description: 'Playback rate multiplier (0.5–2.0)',
+			},
+			{
+				displayName: 'Stability',
+				name: 'stability',
+				type: 'number',
+				default: 50,
+				typeOptions: { minValue: 0, maxValue: 100 },
+				description: 'Voice consistency (0–100; lower is more expressive)',
+			},
+		],
+	},
+	// ElevenLabs Additional Options
 	{
 		displayName: 'Additional Options',
 		name: 'additionalOptions',
@@ -137,6 +315,7 @@ export const SpeechFields: INodeProperties[] = [
 			show: {
 				resource: ['speech'],
 				operation: ['textToSpeech'],
+				provider: ['elevenLabs'],
 			},
 		},
 		options: [

--- a/nodes/elevenlabs/ElevenLabs.node.ts
+++ b/nodes/elevenlabs/ElevenLabs.node.ts
@@ -1,8 +1,33 @@
-import { INodeType, INodeTypeDescription } from 'n8n-workflow';
+import {
+	IDataObject,
+	IExecuteFunctions,
+	IHttpRequestOptions,
+	IN8nHttpFullResponse,
+	INodeExecutionData,
+	INodeType,
+	INodeTypeDescription,
+	NodeOperationError,
+} from 'n8n-workflow';
 import { VoiceOperations, VoiceFields } from './Descriptions/voice';
 import { listSearch } from './Descriptions/utils';
 import { SpeechFields, SpeechOperations } from './Descriptions/speech';
+import {
+	getTtsProvider,
+	SixtyDbTransport,
+	TtsProviderId,
+	TtsRequest,
+} from './providers/tts';
 
+const ELEVENLABS_BASE_URL = 'https://api.elevenlabs.io/v1';
+
+/**
+ * This node is executed programmatically (see `execute()` below) rather than via
+ * n8n's declarative `routing`. The move to `execute()` is what lets Text to Speech
+ * pick between ElevenLabs and 60db — and 60db's HTTP, streaming and WebSocket
+ * transports — behind a single {@link TtsProvider} abstraction. The `routing`
+ * metadata still present in the Descriptions files documents the underlying API
+ * calls but is not used at runtime.
+ */
 export class ElevenLabs implements INodeType {
 	description: INodeTypeDescription = {
 		displayName: 'ElevenLabs',
@@ -22,15 +47,24 @@ export class ElevenLabs implements INodeType {
 			{
 				name: 'elevenLabsApi',
 				required: true,
+				// Required for everything except 60db Text to Speech.
+				displayOptions: {
+					hide: {
+						provider: ['60db'],
+					},
+				},
+			},
+			{
+				name: 'sixtyDbApi',
+				required: true,
+				// Only required when Text to Speech uses the 60db provider.
+				displayOptions: {
+					show: {
+						provider: ['60db'],
+					},
+				},
 			},
 		],
-		requestDefaults: {
-			method: 'POST',
-			baseURL: 'https://api.elevenlabs.io/v1',
-			headers: {
-				'Content-Type': 'application/json',
-			},
-		},
 		properties: [
 			{
 				displayName: 'Resource',
@@ -53,10 +87,315 @@ export class ElevenLabs implements INodeType {
 			...VoiceFields,
 			...SpeechOperations,
 			...SpeechFields,
-		]
+		],
 	};
 
 	methods = {
 		listSearch,
 	};
+
+	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
+		const items = this.getInputData();
+		const resource = this.getNodeParameter('resource', 0) as string;
+		const operation = this.getNodeParameter('operation', 0) as string;
+
+		const returnData: INodeExecutionData[] = [];
+
+		for (let i = 0; i < items.length; i++) {
+			try {
+				let itemResults: INodeExecutionData[];
+				if (resource === 'voice') {
+					itemResults = await handleVoice(this, operation, i);
+				} else if (resource === 'speech') {
+					itemResults = await handleSpeech(this, operation, i);
+				} else {
+					throw new NodeOperationError(this.getNode(), `Unsupported resource: ${resource}`, {
+						itemIndex: i,
+					});
+				}
+				returnData.push(...itemResults);
+			} catch (error) {
+				if (this.continueOnFail()) {
+					returnData.push({
+						json: { error: (error as Error).message },
+						pairedItem: { item: i },
+					});
+					continue;
+				}
+				throw error;
+			}
+		}
+
+		return [returnData];
+	}
+}
+
+// --- Voice resource ----------------------------------------------------------
+
+const VOICE_SIMPLE_FIELDS = [
+	'voice_id',
+	'name',
+	'category',
+	'labels',
+	'description',
+	'preview_url',
+] as const;
+
+function simplifyVoice(voice: IDataObject): IDataObject {
+	const simplified: IDataObject = {};
+	for (const field of VOICE_SIMPLE_FIELDS) {
+		simplified[field] = voice[field];
+	}
+	return simplified;
+}
+
+async function handleVoice(
+	ctx: IExecuteFunctions,
+	operation: string,
+	i: number,
+): Promise<INodeExecutionData[]> {
+	switch (operation) {
+		case 'get': {
+			const voiceId = ctx.getNodeParameter('voice', i, '', { extractValue: true }) as string;
+			const simplify = ctx.getNodeParameter('simplify', i, false) as boolean;
+			const response = (await ctx.helpers.httpRequestWithAuthentication.call(ctx, 'elevenLabsApi', {
+				method: 'GET',
+				url: `${ELEVENLABS_BASE_URL}/voices/${voiceId}`,
+				json: true,
+			})) as IDataObject;
+			return [{ json: simplify ? simplifyVoice(response) : response, pairedItem: { item: i } }];
+		}
+
+		case 'getAll': {
+			const returnAll = ctx.getNodeParameter('returnAll', i, false) as boolean;
+			const simplify = ctx.getNodeParameter('simplify', i, false) as boolean;
+			const qs: IDataObject = {};
+			if (!returnAll) {
+				qs.page_size = ctx.getNodeParameter('limit', i, 50) as number;
+			}
+			const response = (await ctx.helpers.httpRequestWithAuthentication.call(ctx, 'elevenLabsApi', {
+				method: 'GET',
+				url: `${ELEVENLABS_BASE_URL}/voices`,
+				qs,
+				json: true,
+			})) as IDataObject;
+			const voices = (response.voices as IDataObject[]) ?? [];
+			return voices.map((voice) => ({
+				json: simplify ? simplifyVoice(voice) : voice,
+				pairedItem: { item: i },
+			}));
+		}
+
+		case 'createClone': {
+			const name = ctx.getNodeParameter('name', i) as string;
+			const binaryProperty = ctx.getNodeParameter('audioFiles', i, '') as string;
+			const description = ctx.getNodeParameter('additionalFields.description', i, '') as string;
+			const labels = ctx.getNodeParameter('additionalFields.labels', i, '{}') as string;
+			const fileBuffer = await ctx.helpers.getBinaryDataBuffer(i, binaryProperty);
+
+			const formData = new FormData();
+			formData.append('name', name);
+			formData.append('description', description);
+			formData.append('labels', labels);
+			formData.append('files', new Blob([fileBuffer]));
+
+			const response = (await ctx.helpers.httpRequestWithAuthentication.call(ctx, 'elevenLabsApi', {
+				method: 'POST',
+				url: `${ELEVENLABS_BASE_URL}/voices/add`,
+				body: formData,
+			})) as IDataObject;
+			return [{ json: response, pairedItem: { item: i } }];
+		}
+
+		case 'delete': {
+			const voiceId = ctx.getNodeParameter('voice', i, '', { extractValue: true }) as string;
+			const response = (await ctx.helpers.httpRequestWithAuthentication.call(ctx, 'elevenLabsApi', {
+				method: 'DELETE',
+				url: `${ELEVENLABS_BASE_URL}/voices/${voiceId}`,
+				json: true,
+			})) as IDataObject;
+			return [{ json: response, pairedItem: { item: i } }];
+		}
+
+		default:
+			throw new NodeOperationError(ctx.getNode(), `Unsupported voice operation: ${operation}`, {
+				itemIndex: i,
+			});
+	}
+}
+
+// --- Speech resource ---------------------------------------------------------
+
+async function handleSpeech(
+	ctx: IExecuteFunctions,
+	operation: string,
+	i: number,
+): Promise<INodeExecutionData[]> {
+	switch (operation) {
+		case 'textToSpeech':
+			return handleTextToSpeech(ctx, i);
+		case 'speechToText':
+			return handleSpeechToText(ctx, i);
+		case 'speechToSpeech':
+			return handleSpeechToSpeech(ctx, i);
+		default:
+			throw new NodeOperationError(ctx.getNode(), `Unsupported speech operation: ${operation}`, {
+				itemIndex: i,
+			});
+	}
+}
+
+async function handleTextToSpeech(
+	ctx: IExecuteFunctions,
+	i: number,
+): Promise<INodeExecutionData[]> {
+	const provider = ctx.getNodeParameter('provider', i, 'elevenLabs') as TtsProviderId;
+	const text = ctx.getNodeParameter('text', i) as string;
+
+	let request: TtsRequest;
+
+	if (provider === '60db') {
+		const transport = ctx.getNodeParameter('transport', i, 'http') as SixtyDbTransport;
+		const voiceId = ctx.getNodeParameter('sixtyDbVoiceId', i, '') as string;
+		const options = ctx.getNodeParameter('sixtyDbOptions', i, {}) as IDataObject;
+		request = {
+			text,
+			voiceId: voiceId || undefined,
+			transport,
+			enhance: options.enhance as boolean | undefined,
+			speed: options.speed as number | undefined,
+			stability: options.stability as number | undefined,
+			similarity: options.similarity as number | undefined,
+			outputFormat: options.outputFormat as string | undefined,
+			audioEncoding: options.audioEncoding as string | undefined,
+			sampleRate: options.sampleRate as number | undefined,
+		};
+	} else {
+		const voiceId = ctx.getNodeParameter('voice', i, '', { extractValue: true }) as string;
+		const modelId = ctx.getNodeParameter('additionalOptions.model', i, 'eleven_multilingual_v2', {
+			extractValue: true,
+		}) as string;
+		const options = ctx.getNodeParameter('additionalOptions', i, {}) as IDataObject;
+
+		let voiceSettings: IDataObject | undefined;
+		const rawVoiceSettings = options.voiceSettings as string | IDataObject | undefined;
+		if (rawVoiceSettings) {
+			voiceSettings =
+				typeof rawVoiceSettings === 'string'
+					? (JSON.parse(rawVoiceSettings) as IDataObject)
+					: rawVoiceSettings;
+		}
+
+		request = {
+			text,
+			voiceId,
+			modelId,
+			languageCode: options.languageCode as string | undefined,
+			outputFormat: options.outputFormat as string | undefined,
+			voiceSettings,
+		};
+	}
+
+	const result = await getTtsProvider(provider).textToSpeech(ctx, i, request);
+	const binaryData = await ctx.helpers.prepareBinaryData(
+		result.buffer,
+		`audio.textToSpeech.${result.fileExtension}`,
+		result.mimeType,
+	);
+
+	return [
+		{
+			json: result.metadata,
+			binary: { data: binaryData },
+			pairedItem: { item: i },
+		},
+	];
+}
+
+async function handleSpeechToText(
+	ctx: IExecuteFunctions,
+	i: number,
+): Promise<INodeExecutionData[]> {
+	const binaryProperty = ctx.getNodeParameter('file', i, 'data') as string;
+	const fileBuffer = await ctx.helpers.getBinaryDataBuffer(i, binaryProperty);
+
+	const modelId =
+		(ctx.getNodeParameter('additionalOptions.model', i, '', { extractValue: true }) as string) ||
+		'scribe_v1';
+	const languageCode = ctx.getNodeParameter('additionalOptions.languageCode', i, '') as string;
+	const numberOfSpeakers = ctx.getNodeParameter('additionalOptions.numberOfSpeakers', i, 0) as number;
+	const diarize = ctx.getNodeParameter('additionalOptions.diarize', i, undefined) as
+		| boolean
+		| undefined;
+
+	const formData = new FormData();
+	formData.append('file', new Blob([fileBuffer]));
+	formData.append('model_id', modelId);
+	if (languageCode) formData.append('language_code', languageCode);
+	if (numberOfSpeakers) formData.append('num_speakers', String(numberOfSpeakers));
+	if (diarize !== undefined) formData.append('diarize', String(diarize));
+
+	const response = (await ctx.helpers.httpRequestWithAuthentication.call(ctx, 'elevenLabsApi', {
+		method: 'POST',
+		url: `${ELEVENLABS_BASE_URL}/speech-to-text`,
+		body: formData,
+	})) as IDataObject;
+
+	return [{ json: response, pairedItem: { item: i } }];
+}
+
+async function handleSpeechToSpeech(
+	ctx: IExecuteFunctions,
+	i: number,
+): Promise<INodeExecutionData[]> {
+	const voiceId = ctx.getNodeParameter('voice', i, '', { extractValue: true }) as string;
+	const binaryProperty = ctx.getNodeParameter('file', i, 'data') as string;
+	const fileBuffer = await ctx.helpers.getBinaryDataBuffer(i, binaryProperty);
+
+	const modelId =
+		(ctx.getNodeParameter('additionalOptions.model', i, '', { extractValue: true }) as string) ||
+		'eleven_english_sts_v2';
+	const outputFormat = ctx.getNodeParameter('additionalOptions.outputFormat', i, '') as string;
+	const rawVoiceSettings = ctx.getNodeParameter('additionalOptions.voiceSettings', i, '{}') as
+		| string
+		| IDataObject;
+	const voiceSettings =
+		typeof rawVoiceSettings === 'string' ? rawVoiceSettings : JSON.stringify(rawVoiceSettings);
+
+	const formData = new FormData();
+	formData.append('audio', new Blob([fileBuffer]));
+	formData.append('model_id', modelId);
+	formData.append('voice_settings', voiceSettings);
+
+	const qs: IDataObject = {};
+	if (outputFormat) qs.output_format = outputFormat;
+
+	const options: IHttpRequestOptions = {
+		method: 'POST',
+		url: `${ELEVENLABS_BASE_URL}/speech-to-speech/${voiceId}`,
+		body: formData,
+		qs,
+		encoding: 'arraybuffer',
+		returnFullResponse: true,
+	};
+
+	const response = (await ctx.helpers.httpRequestWithAuthentication.call(
+		ctx,
+		'elevenLabsApi',
+		options,
+	)) as IN8nHttpFullResponse;
+
+	const binaryData = await ctx.helpers.prepareBinaryData(
+		Buffer.from(response.body as ArrayBuffer),
+		'audio.speechToSpeech.mp3',
+		'audio/mpeg',
+	);
+
+	return [
+		{
+			json: response.headers as IDataObject,
+			binary: { data: binaryData },
+			pairedItem: { item: i },
+		},
+	];
 }

--- a/nodes/elevenlabs/providers/tts.ts
+++ b/nodes/elevenlabs/providers/tts.ts
@@ -1,0 +1,420 @@
+import type {
+	IDataObject,
+	IExecuteFunctions,
+	IHttpRequestOptions,
+	IN8nHttpFullResponse,
+} from 'n8n-workflow';
+import WebSocket from 'ws';
+
+/**
+ * Provider-agnostic Text-to-Speech abstraction.
+ *
+ * Both ElevenLabs and 60db are exposed through the same {@link TtsProvider}
+ * interface so the node's `execute()` does not care which one is selected — it
+ * builds a normalized {@link TtsRequest} and gets back a normalized
+ * {@link TtsResult} (an audio buffer + how to attach it as binary data).
+ */
+
+export type TtsProviderId = 'elevenLabs' | '60db';
+export type SixtyDbTransport = 'http' | 'stream' | 'websocket';
+
+export interface TtsRequest {
+	text: string;
+	voiceId?: string;
+
+	// ElevenLabs-specific
+	modelId?: string;
+	languageCode?: string;
+	voiceSettings?: IDataObject;
+
+	// Shared / 60db-specific
+	outputFormat?: string;
+	transport?: SixtyDbTransport;
+	speed?: number;
+	stability?: number;
+	similarity?: number;
+	enhance?: boolean;
+
+	// 60db WebSocket-specific
+	audioEncoding?: string;
+	sampleRate?: number;
+}
+
+export interface TtsResult {
+	buffer: Buffer;
+	mimeType: string;
+	fileExtension: string;
+	metadata: IDataObject;
+}
+
+export interface TtsProvider {
+	textToSpeech(ctx: IExecuteFunctions, itemIndex: number, req: TtsRequest): Promise<TtsResult>;
+}
+
+/** Maps an ElevenLabs `output_format` value to a MIME type + file extension. */
+function mapElevenLabsFormat(fmt?: string): { mimeType: string; fileExtension: string } {
+	const f = fmt ?? 'mp3_44100_128';
+	if (f.startsWith('opus')) return { mimeType: 'audio/ogg', fileExtension: 'opus' };
+	if (f.startsWith('pcm')) return { mimeType: 'audio/basic', fileExtension: 'pcm' };
+	if (f.startsWith('ulaw')) return { mimeType: 'audio/basic', fileExtension: 'ulaw' };
+	if (f.startsWith('alaw')) return { mimeType: 'audio/basic', fileExtension: 'alaw' };
+	return { mimeType: 'audio/mpeg', fileExtension: 'mp3' };
+}
+
+/** Maps a 60db HTTP/stream `output_format` value to a MIME type + file extension. */
+function mapSixtyDbFormat(fmt?: string): { mimeType: string; fileExtension: string } {
+	switch ((fmt ?? 'mp3').toLowerCase()) {
+		case 'wav':
+			return { mimeType: 'audio/wav', fileExtension: 'wav' };
+		case 'ogg':
+			return { mimeType: 'audio/ogg', fileExtension: 'ogg' };
+		case 'flac':
+			return { mimeType: 'audio/flac', fileExtension: 'flac' };
+		default:
+			return { mimeType: 'audio/mpeg', fileExtension: 'mp3' };
+	}
+}
+
+/** Wraps raw PCM / G.711 samples in a minimal WAV container so the audio is playable. */
+function wrapInWav(
+	data: Buffer,
+	sampleRate: number,
+	opts: { audioFormat: number; bitsPerSample: number },
+): Buffer {
+	const channels = 1;
+	const { audioFormat, bitsPerSample } = opts;
+	const blockAlign = (channels * bitsPerSample) / 8;
+	const byteRate = sampleRate * blockAlign;
+
+	const header = Buffer.alloc(44);
+	header.write('RIFF', 0);
+	header.writeUInt32LE(36 + data.length, 4);
+	header.write('WAVE', 8);
+	header.write('fmt ', 12);
+	header.writeUInt32LE(16, 16);
+	header.writeUInt16LE(audioFormat, 20);
+	header.writeUInt16LE(channels, 22);
+	header.writeUInt32LE(sampleRate, 24);
+	header.writeUInt32LE(byteRate, 28);
+	header.writeUInt16LE(blockAlign, 32);
+	header.writeUInt16LE(bitsPerSample, 34);
+	header.write('data', 36);
+	header.writeUInt32LE(data.length, 40);
+
+	return Buffer.concat([header, data]);
+}
+
+export class ElevenLabsTtsProvider implements TtsProvider {
+	async textToSpeech(
+		ctx: IExecuteFunctions,
+		_itemIndex: number,
+		req: TtsRequest,
+	): Promise<TtsResult> {
+		const body: IDataObject = { text: req.text };
+		if (req.modelId) body.model_id = req.modelId;
+		// language_code is only honoured by the turbo_v2 / flash_v2 model families.
+		if (
+			req.languageCode &&
+			req.modelId &&
+			(req.modelId.includes('turbo_v2') || req.modelId.includes('flash_v2'))
+		) {
+			body.language_code = req.languageCode;
+		}
+		if (req.voiceSettings) body.voice_settings = req.voiceSettings;
+
+		const qs: IDataObject = {};
+		if (req.outputFormat) qs.output_format = req.outputFormat;
+
+		const options: IHttpRequestOptions = {
+			method: 'POST',
+			url: `https://api.elevenlabs.io/v1/text-to-speech/${req.voiceId}`,
+			body,
+			qs,
+			json: true,
+			encoding: 'arraybuffer',
+			returnFullResponse: true,
+		};
+
+		const response = (await ctx.helpers.httpRequestWithAuthentication.call(
+			ctx,
+			'elevenLabsApi',
+			options,
+		)) as IN8nHttpFullResponse;
+
+		const buffer = Buffer.from(response.body as ArrayBuffer);
+		const { mimeType, fileExtension } = mapElevenLabsFormat(req.outputFormat);
+
+		return {
+			buffer,
+			mimeType,
+			fileExtension,
+			metadata: {
+				provider: 'elevenLabs',
+				voice_id: req.voiceId,
+				model_id: req.modelId,
+				output_format: req.outputFormat,
+			},
+		};
+	}
+}
+
+export class SixtyDbTtsProvider implements TtsProvider {
+	async textToSpeech(
+		ctx: IExecuteFunctions,
+		itemIndex: number,
+		req: TtsRequest,
+	): Promise<TtsResult> {
+		switch (req.transport ?? 'http') {
+			case 'stream':
+				return this.synthesizeStream(ctx, req);
+			case 'websocket':
+				return this.synthesizeWebSocket(ctx, itemIndex, req);
+			case 'http':
+			default:
+				return this.synthesizeHttp(ctx, req);
+		}
+	}
+
+	/** Builds the JSON body shared by the HTTP and streaming endpoints. */
+	private buildBody(req: TtsRequest): IDataObject {
+		const body: IDataObject = { text: req.text };
+		if (req.voiceId) body.voice_id = req.voiceId;
+		if (req.enhance !== undefined) body.enhance = req.enhance;
+		if (req.speed !== undefined) body.speed = req.speed;
+		if (req.stability !== undefined) body.stability = req.stability;
+		if (req.similarity !== undefined) body.similarity = req.similarity;
+		if (req.outputFormat) body.output_format = req.outputFormat;
+		return body;
+	}
+
+	/** POST /tts-synthesize — returns a JSON envelope with base64 audio. */
+	private async synthesizeHttp(ctx: IExecuteFunctions, req: TtsRequest): Promise<TtsResult> {
+		const options: IHttpRequestOptions = {
+			method: 'POST',
+			url: 'https://api.60db.ai/tts-synthesize',
+			body: this.buildBody(req),
+			json: true,
+		};
+
+		const response = (await ctx.helpers.httpRequestWithAuthentication.call(
+			ctx,
+			'sixtyDbApi',
+			options,
+		)) as IDataObject;
+
+		if (response.success === false) {
+			throw new Error(`60db TTS failed: ${response.message ?? 'unknown error'}`);
+		}
+
+		const audioBase64 = response.audio_base64 as string;
+		if (!audioBase64) {
+			throw new Error('60db TTS response did not contain audio_base64');
+		}
+
+		const buffer = Buffer.from(audioBase64, 'base64');
+		const { mimeType, fileExtension } = mapSixtyDbFormat(
+			(response.output_format as string) ?? req.outputFormat,
+		);
+
+		return {
+			buffer,
+			mimeType,
+			fileExtension,
+			metadata: {
+				provider: '60db',
+				transport: 'http',
+				voice_id: req.voiceId,
+				sample_rate: response.sample_rate,
+				duration_seconds: response.duration_seconds,
+				encoding: response.encoding,
+				output_format: response.output_format ?? req.outputFormat,
+			},
+		};
+	}
+
+	/** POST /tts-stream — NDJSON chunks; concatenated into a single buffer. */
+	private async synthesizeStream(ctx: IExecuteFunctions, req: TtsRequest): Promise<TtsResult> {
+		const options: IHttpRequestOptions = {
+			method: 'POST',
+			url: 'https://api.60db.ai/tts-stream',
+			headers: { 'Content-Type': 'application/json' },
+			body: JSON.stringify(this.buildBody(req)),
+			json: false,
+			returnFullResponse: true,
+		};
+
+		const response = (await ctx.helpers.httpRequestWithAuthentication.call(
+			ctx,
+			'sixtyDbApi',
+			options,
+		)) as IN8nHttpFullResponse;
+
+		const raw =
+			typeof response.body === 'string'
+				? response.body
+				: Buffer.from(response.body as ArrayBuffer).toString('utf8');
+
+		const chunks: Buffer[] = [];
+		for (const line of raw.split(/\r?\n/)) {
+			const trimmed = line.trim();
+			if (!trimmed) continue;
+			let message: IDataObject;
+			try {
+				message = JSON.parse(trimmed) as IDataObject;
+			} catch {
+				continue;
+			}
+			if (message.type === 'error') {
+				throw new Error(`60db streaming error: ${message.message ?? 'unknown error'}`);
+			}
+			if (message.type === 'chunk') {
+				const result = message.result as IDataObject | undefined;
+				const audioContent = result?.audioContent as string | undefined;
+				if (audioContent) chunks.push(Buffer.from(audioContent, 'base64'));
+			}
+		}
+
+		const { mimeType, fileExtension } = mapSixtyDbFormat(req.outputFormat);
+
+		return {
+			buffer: Buffer.concat(chunks),
+			mimeType,
+			fileExtension,
+			metadata: {
+				provider: '60db',
+				transport: 'stream',
+				voice_id: req.voiceId,
+				output_format: req.outputFormat,
+				chunks: chunks.length,
+			},
+		};
+	}
+
+	/**
+	 * WebSocket synthesis (wss://api.60db.ai/ws/tts).
+	 *
+	 * Protocol: create_context -> send_text -> flush_context, collect audio_chunk
+	 * frames until flush_completed, then close_context and wait for context_closed.
+	 * Audio frames are raw samples (PCM / G.711), so LINEAR16 and MULAW are wrapped
+	 * in a WAV container to make the result directly playable.
+	 */
+	private async synthesizeWebSocket(
+		ctx: IExecuteFunctions,
+		itemIndex: number,
+		req: TtsRequest,
+	): Promise<TtsResult> {
+		const credentials = await ctx.getCredentials('sixtyDbApi');
+		const apiKey = credentials.apiKey as string;
+
+		const encoding = (req.audioEncoding ?? 'LINEAR16').toUpperCase();
+		const sampleRate = req.sampleRate ?? (encoding === 'MULAW' ? 8000 : 16000);
+		const contextId = `n8n-${itemIndex}-${Date.now()}`;
+		const url = `wss://api.60db.ai/ws/tts?apiKey=${encodeURIComponent(apiKey)}`;
+
+		const chunks: Buffer[] = [];
+
+		await new Promise<void>((resolve, reject) => {
+			const ws = new WebSocket(url);
+			let flushed = false;
+			const timeout = setTimeout(() => {
+				ws.terminate();
+				reject(new Error('60db WebSocket synthesis timed out after 60s'));
+			}, 60_000);
+
+			const finish = (err?: Error) => {
+				clearTimeout(timeout);
+				try {
+					ws.close();
+				} catch {
+					// ignore
+				}
+				if (err) reject(err);
+				else resolve();
+			};
+
+			ws.on('open', () => {
+				ws.send(
+					JSON.stringify({
+						create_context: {
+							context_id: contextId,
+							voice_id: req.voiceId,
+							audio_config: {
+								audio_encoding: encoding,
+								sample_rate_hertz: sampleRate,
+							},
+							speed: req.speed ?? 1,
+							stability: req.stability ?? 50,
+							similarity: req.similarity ?? 75,
+						},
+					}),
+				);
+				ws.send(JSON.stringify({ send_text: { context_id: contextId, text: req.text } }));
+				ws.send(JSON.stringify({ flush_context: { context_id: contextId } }));
+			});
+
+			ws.on('message', (data: WebSocket.RawData) => {
+				let message: IDataObject;
+				try {
+					message = JSON.parse(data.toString()) as IDataObject;
+				} catch {
+					return;
+				}
+
+				const audioChunk = message.audio_chunk as IDataObject | undefined;
+				if (audioChunk?.audioContent) {
+					chunks.push(Buffer.from(audioChunk.audioContent as string, 'base64'));
+					return;
+				}
+				if (message.flush_completed && !flushed) {
+					flushed = true;
+					ws.send(JSON.stringify({ close_context: { context_id: contextId } }));
+					return;
+				}
+				if (message.context_closed) {
+					finish();
+					return;
+				}
+				if (message.error || message.type === 'error') {
+					const detail =
+						(typeof message.error === 'string' ? message.error : undefined) ??
+						(message.message as string) ??
+						'unknown error';
+					finish(new Error(`60db WebSocket error: ${detail}`));
+				}
+			});
+
+			ws.on('error', (err: Error) => finish(err));
+		});
+
+		const raw = Buffer.concat(chunks);
+
+		if (encoding === 'LINEAR16') {
+			return {
+				buffer: wrapInWav(raw, sampleRate, { audioFormat: 1, bitsPerSample: 16 }),
+				mimeType: 'audio/wav',
+				fileExtension: 'wav',
+				metadata: { provider: '60db', transport: 'websocket', encoding, sampleRate },
+			};
+		}
+		if (encoding === 'MULAW') {
+			return {
+				buffer: wrapInWav(raw, sampleRate, { audioFormat: 7, bitsPerSample: 8 }),
+				mimeType: 'audio/wav',
+				fileExtension: 'wav',
+				metadata: { provider: '60db', transport: 'websocket', encoding, sampleRate },
+			};
+		}
+		// OGG_OPUS frames are self-contained; passed through unwrapped.
+		return {
+			buffer: raw,
+			mimeType: 'audio/ogg',
+			fileExtension: 'ogg',
+			metadata: { provider: '60db', transport: 'websocket', encoding, sampleRate },
+		};
+	}
+}
+
+/** Returns the TTS provider implementation for the given provider id. */
+export function getTtsProvider(providerId: TtsProviderId): TtsProvider {
+	return providerId === '60db' ? new SixtyDbTtsProvider() : new ElevenLabsTtsProvider();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,12 @@
       "name": "@elevenlabs/n8n-nodes-elevenlabs",
       "version": "0.2.4",
       "license": "MIT",
+      "dependencies": {
+        "ws": "^8.18.0"
+      },
       "devDependencies": {
         "@types/node": "^20.12.8",
+        "@types/ws": "^8.5.10",
         "@typescript-eslint/parser": "~8.32.0",
         "eslint": "^8.57.0",
         "eslint-plugin-n8n-nodes-base": "^1.16.3",
@@ -307,6 +311,16 @@
       "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/parser": {
       "version": "8.32.1",
@@ -4390,6 +4404,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
     },
     "node_modules/xml2js": {
       "version": "0.6.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
   "n8n": {
     "n8nNodesApiVersion": 1,
     "credentials": [
-      "dist/credentials/ElevenLabsApi.credentials.js"
+      "dist/credentials/ElevenLabsApi.credentials.js",
+      "dist/credentials/SixtyDbApi.credentials.js"
     ],
     "nodes": [
       "dist/nodes/elevenlabs/ElevenLabs.node.js"
@@ -58,12 +59,16 @@
   },
   "devDependencies": {
     "@types/node": "^20.12.8",
+    "@types/ws": "^8.5.10",
     "@typescript-eslint/parser": "~8.32.0",
     "eslint": "^8.57.0",
     "eslint-plugin-n8n-nodes-base": "^1.16.3",
     "gulp": "^5.0.0",
     "prettier": "^3.5.3",
     "typescript": "^5.8.2"
+  },
+  "dependencies": {
+    "ws": "^8.18.0"
   },
   "peerDependencies": {
     "n8n-workflow": "*"


### PR DESCRIPTION
Added 60dB AI provider support for STT, TTS, and LLM services. The integration follows the existing provider pattern and has been validated with end-to-end voice conversation testing. Looking forward to feedback and review.
